### PR TITLE
Hilbert loader, load selected CPUs and fix plane plots

### DIFF
--- a/docs/loading_data.ipynb
+++ b/docs/loading_data.ipynb
@@ -70,7 +70,7 @@
    "outputs": [],
    "source": [
     "data2 = osyris.load(71, scale=\"au\", path=\"osyrisdata\",\n",
-    "                    select={\"density\": lambda x : x > 1.0e-13})"
+    "                    select={\"density\": lambda d : d > 1.0e-13 * osyris.units('g/cm**3')})"
    ]
   },
   {
@@ -104,8 +104,8 @@
    "outputs": [],
    "source": [
     "data3 = osyris.load(71, scale=\"au\", path=\"osyrisdata\",\n",
-    "                    select={\"density\": lambda x : x > 1.0e-13,\n",
-    "                            \"xyz_x\": lambda x : abs(x - 5517.) < 50})"
+    "                    select={\"density\": lambda d : d > 1.0e-13 * osyris.units('g/cm**3'),\n",
+    "                            \"xyz_x\": lambda x : x > 5500. * osyris.units('au')})"
    ]
   },
   {
@@ -120,6 +120,54 @@
     "             dx=200,\n",
     "             origin=center,\n",
     "             direction='z')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading only selected CPU outputs\n",
+    "\n",
+    "It is also possible to feed a list of CPU numbers to read from."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data4 = osyris.load(71, scale=\"au\", path=\"osyrisdata\",\n",
+    "                    cpu_list=[1, 2, 10, 4, 5])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ind = np.argmax(data4[\"density\"])\n",
+    "center = data4[\"xyz\"][ind.values]\n",
+    "osyris.plane({\"data\": data4[\"density\"], \"norm\": \"log\"},\n",
+    "             dx=400,\n",
+    "             origin=center,\n",
+    "             direction='z')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "**Note**\n",
+    "\n",
+    "When performing a selection (using `select`) on spatial position `x`, `y`, or `z`,\n",
+    "and if the ordering of the cells in the AMR mesh is using the Hilbert curve,\n",
+    "then a pre-selection is automatically made on the CPU files to load to speed-up the loading.\n",
+    "\n",
+    "</div>"
    ]
   }
  ],
@@ -139,7 +187,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/src/osyris/core/array.py
+++ b/src/osyris/core/array.py
@@ -18,7 +18,7 @@ def _comparison_operator(lhs, rhs, op):
 class Array:
     def __init__(self, values=None, unit=None, parent=None, name=""):
 
-        self._array = values
+        self._array = np.asarray(values)
 
         if unit is None:
             self._unit = 1.0 * units.dimensionless
@@ -172,8 +172,7 @@ class Array:
                 return lhs.reshape(tuple([1]) + lhs.shape), rhs
 
     def _raise_incompatible_units_error(self, other, op):
-        raise TypeError("Could not {} types {} and {}.".format(
-            op, type(self), type(other)))
+        raise TypeError("Could not {} types {} and {}.".format(op, self, other))
 
     def __add__(self, other):
         if isinstance(other, self.__class__):
@@ -345,8 +344,20 @@ class Array:
         if func.__name__ in self.special_functions:
             unit = func(self.unit, *args[1:], **kwargs)
         else:
-            unit = self._unit
-        args = (args[0]._array, ) + args[1:]
+            unit = self.unit
+        if isinstance(args[0], tuple) or isinstance(args[0], list):
+            # Case where we have a sequence of arrays, e.g. `concatenate`
+            for a in args[0]:
+                if a.unit != unit:
+                    self._raise_incompatible_units_error(a, func.__name__)
+            args = (tuple(a._array for a in args[0]), ) + args[1:]
+        elif (len(args) > 1 and hasattr(args[1], "_array")):
+            # Case of a binary operation, e.g. `dot`.
+            # TODO: what should we do with the unit? Apply the func to it?
+            args = (args[0]._array, args[1]._array) + args[2:]
+            unit = func(args[0].unit, args[1].unit, *args[2:], **kwargs)
+        else:
+            args = (args[0]._array, ) + args[1:]
         result = func(*args, **kwargs)
         return self.__class__(values=result, unit=unit)
 

--- a/src/osyris/core/array.py
+++ b/src/osyris/core/array.py
@@ -352,10 +352,18 @@ class Array:
                     self._raise_incompatible_units_error(a, func.__name__)
             args = (tuple(a._array for a in args[0]), ) + args[1:]
         elif (len(args) > 1 and hasattr(args[1], "_array")):
-            # Case of a binary operation, e.g. `dot`.
-            # TODO: what should we do with the unit? Apply the func to it?
-            args = (args[0]._array, args[1]._array) + args[2:]
-            unit = func(args[0].unit, args[1].unit, *args[2:], **kwargs)
+            if hasattr(args[0], "_array"):
+                # Case of a binary operation, with two Arrays, e.g. `dot`
+                # TODO: what should we do with the unit? Apply the func to it?
+                args = (args[0]._array, args[1]._array) + args[2:]
+                unit = func(args[0].unit, args[1].unit, *args[2:], **kwargs)
+            else:
+                # Case of a binary operation: ndarray with Array
+                # In this case, only multiply is allowed?
+                if func.__name__ != "multiply":
+                    raise RuntimeError("Cannot use operation {} between ndarray and "
+                                       "Array".format(func.__name__))
+                args = (args[0], args[1]._array) + args[2:]
         else:
             args = (args[0]._array, ) + args[1:]
         result = func(*args, **kwargs)

--- a/src/osyris/core/array.py
+++ b/src/osyris/core/array.py
@@ -18,7 +18,10 @@ def _comparison_operator(lhs, rhs, op):
 class Array:
     def __init__(self, values=None, unit=None, parent=None, name=""):
 
-        self._array = np.asarray(values)
+        if isinstance(values, np.ndarray):
+            self._array = values
+        else:
+            self._array = np.asarray(values)
 
         if unit is None:
             self._unit = 1.0 * units.dimensionless

--- a/src/osyris/io/amr.py
+++ b/src/osyris/io/amr.py
@@ -173,15 +173,15 @@ class AmrLoader(Loader):
                                                         content=self.bytes,
                                                         offsets=self.offsets)
 
-        self.variables["level"]["buffer"][:ncache, ind] = ilevel + 1
+        self.variables["level"]["buffer"]._array[:ncache, ind] = ilevel + 1
         for n in range(info["ndim"]):
             key = "xyz_" + "xyz"[n]
-            self.variables[key]["buffer"][:ncache, ind] = (
+            self.variables[key]["buffer"]._array[:ncache, ind] = (
                 self.xg[:ncache, n] + self.xcent[ind, n] - self.meta["xbound"][n]
             ) * info["boxlen"] * self.variables[key]["unit"].magnitude
-        self.variables["dx"]["buffer"][:ncache, ind] = self.dxcell * info[
+        self.variables["dx"]["buffer"]._array[:ncache, ind] = self.dxcell * info[
             "boxlen"] * self.variables["dx"]["unit"].magnitude
-        self.variables["cpu"]["buffer"][:ncache, ind] = cpuid + 1
+        self.variables["cpu"]["buffer"]._array[:ncache, ind] = cpuid + 1
 
         # Note: use lmax here instead of levelmax because the user might not
         # want to load all levels. levelmax is always the max level in the

--- a/src/osyris/io/amr.py
+++ b/src/osyris/io/amr.py
@@ -1,4 +1,6 @@
 import numpy as np
+from ..core import Array
+from .hilbert import hilbert_cpu_list
 from .loader import Loader
 from .units import get_unit
 from .. import units
@@ -6,11 +8,13 @@ from . import utils
 
 
 class AmrLoader(Loader):
-    def __init__(self, scale=None, code_units=None, ndim=1):
+    def __init__(self, scale, select, code_units, meta, infofile):
+        # ndim, ordering, boxlen, levelmax):
 
         super().__init__()
 
         self.initialized = True
+        self.cpu_list = None
         # AMR grid variables
         length_unit = get_unit("x", code_units["ud"], code_units["ul"],
                                code_units["ut"])
@@ -51,8 +55,52 @@ class AmrLoader(Loader):
                 "pieces": {},
                 "unit": scaling
             }
-            for c in "xyz"[:ndim]
+            for c in "xyz"[:meta["ndim"]]
         })
+
+        if meta["ordering type"] == "hilbert":
+            bounding_box = {
+                "xmin": 0,
+                "xmax": 1,
+                "ymin": 0,
+                "ymax": 1,
+                "zmin": 0,
+                "zmax": 1
+            }
+            # Make an array of cell centers according to lmax
+            box_size = (meta["boxlen"] * scaling).magnitude
+            ncells = 2**min(meta["levelmax"], 18)  # limit to 262000 cells
+            half_dxmin = 0.5 * box_size / ncells
+            xyz_centers = Array(values=np.linspace(half_dxmin, box_size - half_dxmin,
+                                                   ncells),
+                                unit=1.0 * scaling.units)
+            # print(xyz_centers)
+            # print(xyz_centers.values)
+            # raise RuntimeError(' ')
+            new_bbox = False
+            for c in "xyz":
+                print(c, c in select, select)
+                if c in select:
+                    new_bbox = True
+                    # func_test = np.vectorize(select["x"])
+                    # func_test = np.vectorize(select["x"])(xyz_centers)
+                    func_test = select[c](xyz_centers)
+                    inds = np.argwhere(func_test).ravel()
+                    start = xyz_centers[inds.min()] - (half_dxmin * scaling.units)
+                    end = xyz_centers[inds.max()] + (half_dxmin * scaling.units)
+                    bounding_box["{}min".format(c)] = start._array / box_size
+                    bounding_box["{}max".format(c)] = end._array / box_size
+                    select["xyz_{}".format(c)] = select.pop(c)
+                    # del select[c]
+            print(bounding_box)
+
+            if new_bbox:
+                self.cpu_list = hilbert_cpu_list(bounding_box=bounding_box,
+                                                 lmax=meta["lmax"],
+                                                 levelmax=meta["levelmax"],
+                                                 infofile=infofile,
+                                                 ncpu=meta["ncpu"],
+                                                 ndim=meta["ndim"])
 
     def allocate_buffers(self, ngridmax, twotondim):
         super().allocate_buffers(ngridmax, twotondim)

--- a/src/osyris/io/hilbert.py
+++ b/src/osyris/io/hilbert.py
@@ -4,10 +4,138 @@
 import numpy as np
 
 
-def hilbert_cpu_list(bounding_box, lmax, levelmax, infofile, ncpu):
+def _read_bound_key(infofile, ncpu):
+    """
+    Read hilbert bound key.
+    """
+    with open(infofile) as f:
+        content = f.readlines()
+    starting_line = None
+    for num, line in enumerate(content):
+        if len(set(["DOMAIN", "ind_min", "ind_max"]) - set(line.split())) == 0:
+            starting_line = num + 1
+            break
+    bound_key = []
+    if starting_line is not None:
+        for n in range(ncpu):
+            line = content[starting_line + n].split()
+            bound_key.append(int(float(line[1])))
+        bound_key.append(int(float(content[starting_line + ncpu - 1].split()[2])))
+
+    # return np.array(bound_key, dtype=float)
+    return bound_key
+
+
+def _btest(i, pos):
+    return bool(i & (1 << pos))
+
+
+def _hilbert3d(x, y, z, bit_length):
+
+    # logical,dimension(0:3*bit_length-1)::i_bit_mask
+    # logical,dimension(0:1*bit_length-1)::x_bit_mask,y_bit_mask,z_bit_mask
+    # integer,dimension(0:7,0:1,0:11)::state_diagram
+
+    # integer::i,ip,cstate,nstate,b0,b1,b2,sdigit,hdigit
+
+    # if(bit_length>bit_size(bit_length))then
+    #  write(*,*)'Maximum bit length=',bit_size(bit_length)
+    #  write(*,*)'stop in hilbert3d'
+    #  stop
+    # endif
+
+    i_bit_mask = np.zeros(3 * bit_length, dtype=bool)
+    x_bit_mask = np.zeros(bit_length, dtype=bool)
+    y_bit_mask = np.zeros_like(x_bit_mask)
+    z_bit_mask = np.zeros_like(x_bit_mask)
+    # logical,dimension(0:3*bit_length-1)::i_bit_mask
+    # logical,dimension(0:1*bit_length-1)::x_bit_mask,y_bit_mask,z_bit_mask
+
+    # state_diagram = RESHAPE( (/   1, 2, 3, 2, 4, 5, 3, 5,&
+    #    &   0, 1, 3, 2, 7, 6, 4, 5,&
+    #    &   2, 6, 0, 7, 8, 8, 0, 7,&
+    #    &   0, 7, 1, 6, 3, 4, 2, 5,&
+    #    &   0, 9,10, 9, 1, 1,11,11,&
+    #    &   0, 3, 7, 4, 1, 2, 6, 5,&
+    #    &   6, 0, 6,11, 9, 0, 9, 8,&
+    #    &   2, 3, 1, 0, 5, 4, 6, 7,&
+    #    &  11,11, 0, 7, 5, 9, 0, 7,&
+    #    &   4, 3, 5, 2, 7, 0, 6, 1,&
+    #    &   4, 4, 8, 8, 0, 6,10, 6,&
+    #    &   6, 5, 1, 2, 7, 4, 0, 3,&
+    #    &   5, 7, 5, 3, 1, 1,11,11,&
+    #    &   4, 7, 3, 0, 5, 6, 2, 1,&
+    #    &   6, 1, 6,10, 9, 4, 9,10,&
+    #    &   6, 7, 5, 4, 1, 0, 2, 3,&
+    #    &  10, 3, 1, 1,10, 3, 5, 9,&
+    #    &   2, 5, 3, 4, 1, 6, 0, 7,&
+    #    &   4, 4, 8, 8, 2, 7, 2, 3,&
+    #    &   2, 1, 5, 6, 3, 0, 4, 7,&
+    #    &   7, 2,11, 2, 7, 5, 8, 5,&
+    #    &   4, 5, 7, 6, 3, 2, 0, 1,&
+    #    &  10, 3, 2, 6,10, 3, 4, 4,&
+    #    &   6, 1, 7, 0, 5, 2, 4, 3 /), &
+    #    & (/8 ,2, 12 /) )
+
+    state_diagram = np.array([
+        1, 2, 3, 2, 4, 5, 3, 5, 0, 1, 3, 2, 7, 6, 4, 5, 2, 6, 0, 7, 8, 8, 0, 7, 0, 7, 1,
+        6, 3, 4, 2, 5, 0, 9, 10, 9, 1, 1, 11, 11, 0, 3, 7, 4, 1, 2, 6, 5, 6, 0, 6, 11,
+        9, 0, 9, 8, 2, 3, 1, 0, 5, 4, 6, 7, 11, 11, 0, 7, 5, 9, 0, 7, 4, 3, 5, 2, 7, 0,
+        6, 1, 4, 4, 8, 8, 0, 6, 10, 6, 6, 5, 1, 2, 7, 4, 0, 3, 5, 7, 5, 3, 1, 1, 11, 11,
+        4, 7, 3, 0, 5, 6, 2, 1, 6, 1, 6, 10, 9, 4, 9, 10, 6, 7, 5, 4, 1, 0, 2, 3, 10, 3,
+        1, 1, 10, 3, 5, 9, 2, 5, 3, 4, 1, 6, 0, 7, 4, 4, 8, 8, 2, 7, 2, 3, 2, 1, 5, 6,
+        3, 0, 4, 7, 7, 2, 11, 2, 7, 5, 8, 5, 4, 5, 7, 6, 3, 2, 0, 1, 10, 3, 2, 6, 10, 3,
+        4, 4, 6, 1, 7, 0, 5, 2, 4, 3
+    ]).reshape(8, 2, 12)
+
+    # convert to binary
+    for i in range(bit_length):
+        x_bit_mask[i] = _btest(x, i)
+        y_bit_mask[i] = _btest(y, i)
+        z_bit_mask[i] = _btest(z, i)
+
+    # interleave bits
+    for i in range(bit_length):
+        i_bit_mask[3 * i + 2] = x_bit_mask[i]
+        i_bit_mask[3 * i + 1] = y_bit_mask[i]
+        i_bit_mask[3 * i] = z_bit_mask[i]
+
+    # build Hilbert ordering using state diagram
+    cstate = 0
+    for i in range(bit_length - 1, 1, -1):
+        b2 = 0
+        if i_bit_mask[3 * i + 2]:
+            b2 = 1
+        b1 = 0
+        if i_bit_mask[3 * i + 1]:
+            b1 = 1
+        b0 = 0
+        if i_bit_mask[3 * i]:
+            b0 = 1
+        sdigit = b2 * 4 + b1 * 2 + b0
+        nstate = state_diagram[sdigit, 0, cstate]
+        hdigit = state_diagram[sdigit, 1, cstate]
+        i_bit_mask[3 * i + 2] = _btest(hdigit, 2)
+        i_bit_mask[3 * i + 1] = _btest(hdigit, 1)
+        i_bit_mask[3 * i] = _btest(hdigit, 0)
+        cstate = nstate
+
+    # save Hilbert key as double precision real ??
+    order = 0
+    for i in range(3 * bit_length):
+        b0 = 0
+        if i_bit_mask[i]:
+            b0 = 1
+        order = order + b0 * (2**i)
+
+    return order
+
+
+def hilbert_cpu_list(bounding_box, lmax, levelmax, infofile, ncpu, ndim):
 
     # Read bound key
-    bound_key = read_bound_key(infofile=infofile, ncpu=ncpu)
+    bound_key = _read_bound_key(infofile=infofile, ncpu=ncpu)
+    print(bound_key)
 
     xmin = bounding_box["xmin"]
     xmax = bounding_box["xmax"]
@@ -51,83 +179,62 @@ def hilbert_cpu_list(bounding_box, lmax, levelmax, infofile, ncpu):
     ndom = 1
     if bit_length > 0:
         ndom = 8
-    idom = [[imin, imax]] * 4
-    jdom = [[jmin, jmax]] * 4
-    kdom = [[kmin, kmax]] * 4
+    idom = [imin, imax] * 4
+    jdom = [jmin, jmax] * 4
+    kdom = [kmin, kmax] * 4
 
-# idom(1)=imin; idom(2)=imax
-# idom(3)=imin; idom(4)=imax
-# idom(5)=imin; idom(6)=imax
-# idom(7)=imin; idom(8)=imax
-# jdom(1)=jmin; jdom(2)=jmin
-# jdom(3)=jmax; jdom(4)=jmax
-# jdom(5)=jmin; jdom(6)=jmin
-# jdom(7)=jmax; jdom(8)=jmax
-# kdom(1)=kmin; kdom(2)=kmin
-# kdom(3)=kmin; kdom(4)=kmin
-# kdom(5)=kmax; kdom(6)=kmax
-# kdom(7)=kmax; kdom(8)=kmax
+    # idom(1)=imin; idom(2)=imax
+    # idom(3)=imin; idom(4)=imax
+    # idom(5)=imin; idom(6)=imax
+    # idom(7)=imin; idom(8)=imax
+    # jdom(1)=jmin; jdom(2)=jmin
+    # jdom(3)=jmax; jdom(4)=jmax
+    # jdom(5)=jmin; jdom(6)=jmin
+    # jdom(7)=jmax; jdom(8)=jmax
+    # kdom(1)=kmin; kdom(2)=kmin
+    # kdom(3)=kmin; kdom(4)=kmin
+    # kdom(5)=kmax; kdom(6)=kmax
+    # kdom(7)=kmax; kdom(8)=kmax
+
+    # do i=1,ndom
+
+    bounding_min = [0, 0, 0, 0, 0, 0, 0, 0]
+    bounding_max = [0, 0, 0, 0, 0, 0, 0, 0]
+    for i in range(ndom):
+        if bit_length > 0:
+            bounding = _hilbert3d(idom[i], jdom[i], kdom[i], bit_length)
+            order_min = bounding
+        else:
+            order_min = 0
+        bounding_min[i] = order_min * dkey
+        bounding_max[i] = (order_min + 1) * dkey
+
+    cpu_min = [0, 0, 0, 0, 0, 0, 0, 0]
+    cpu_max = [0, 0, 0, 0, 0, 0, 0, 0]
+    for impi in range(ncpu):
+        for i in range(ndom):
+            if ((bound_key[impi] <= bounding_min[i])
+                    and (bound_key[impi + 1] > bounding_min[i])):
+                cpu_min[i] = impi
+
+            if ((bound_key[impi] < bounding_max[i])
+                    and (bound_key[impi + 1] >= bounding_max[i])):
+                cpu_max[i] = impi
+
+    # ncpu_read=0
+    cpu_list = []
+    for i in range(ndom):
+        for j in range(cpu_min[i], cpu_max[i] + 1):
+            if j + 1 not in cpu_list:
+                cpu_list.append(j + 1)
+
+    print(cpu_list)
+    return cpu_list
 
 
-#    do i=1,ndom
-#       if(bit_length>0)then
-#          call hilbert3d(idom(i),jdom(i),kdom(i),bounding(1),bit_length,1)
-#          order_min=bounding(1)
-#       else
-#          order_min=0.0d0
-#       endif
-#       bounding_min(i)=(order_min)*dkey
-#       bounding_max(i)=(order_min+1.0D0)*dkey
-#    end do
-
-#    cpu_min=0; cpu_max=0
-#    do impi=1,ncpu
-#       do i=1,ndom
-#          if (   bound_key(impi-1).le.bounding_min(i).and.&
-#               & bound_key(impi  ).gt.bounding_min(i))then
-#             cpu_min(i)=impi
-#          endif
-#          if (   bound_key(impi-1).lt.bounding_max(i).and.&
-#               & bound_key(impi  ).ge.bounding_max(i))then
-#             cpu_max(i)=impi
-#          endif
-#       end do
-#    end do
-
-#    ncpu_read=0
-#    do i=1,ndom
-#       do j=cpu_min(i),cpu_max(i)
-#          if(.not. cpu_read(j))then
-#             ncpu_read=ncpu_read+1
-#             cpu_list(ncpu_read)=j
-#             cpu_read(j)=.true.
-#          endif
-#       enddo
-#    enddo
 # else
 #    ncpu_read=ncpu
 #    do j=1,ncpu
 #       cpu_list(j)=j
 #    end do
 # end  if
-
-
-def read_bound_key(infofile, ncpu):
-    """
-    Read hilbert bound key.
-    """
-    with open(infofile) as f:
-        content = f.readlines()
-    starting_line = None
-    for num, line in enumerate(content):
-        if len(set(["DOMAIN", "ind_min", "ind_max"]) - set(line.split())) == 0:
-            starting_line = num + 1
-            break
-    bound_key = []
-    if starting_line is not None:
-        for n in range(ncpu):
-            line = content[starting_line + n].split()
-            bound_key.append(line[1])
-        bound_key.append(content[starting_line + ncpu - 1].split()[2])
-
-    return np.array(bound_key, dtype=float)

--- a/src/osyris/io/hilbert.py
+++ b/src/osyris/io/hilbert.py
@@ -2,12 +2,10 @@
 # Copyright (c) 2021 Osyris contributors (https://github.com/nvaytet/osyris)
 
 import numpy as np
+from ..core import Array
 
 
 def _read_bound_key(infofile, ncpu):
-    """
-    Read hilbert bound key.
-    """
     with open(infofile) as f:
         content = f.readlines()
     starting_line = None
@@ -21,8 +19,6 @@ def _read_bound_key(infofile, ncpu):
             line = content[starting_line + n].split()
             bound_key.append(int(float(line[1])))
         bound_key.append(int(float(content[starting_line + ncpu - 1].split()[2])))
-
-    # return np.array(bound_key, dtype=float)
     return bound_key
 
 
@@ -32,52 +28,10 @@ def _btest(i, pos):
 
 def _hilbert3d(x, y, z, bit_length):
 
-    # logical,dimension(0:3*bit_length-1)::i_bit_mask
-    # logical,dimension(0:1*bit_length-1)::x_bit_mask,y_bit_mask,z_bit_mask
-    # integer,dimension(0:7,0:1,0:11)::state_diagram
-
-    # integer::i,ip,cstate,nstate,b0,b1,b2,sdigit,hdigit
-
-    # if(bit_length>bit_size(bit_length))then
-    #  write(*,*)'Maximum bit length=',bit_size(bit_length)
-    #  write(*,*)'stop in hilbert3d'
-    #  stop
-    # endif
-    # print('============')
-    # print(x, y, z, bit_length)
-
     i_bit_mask = np.zeros(3 * bit_length, dtype=bool)
     x_bit_mask = np.zeros(bit_length, dtype=bool)
     y_bit_mask = np.zeros_like(x_bit_mask)
     z_bit_mask = np.zeros_like(x_bit_mask)
-    # logical,dimension(0:3*bit_length-1)::i_bit_mask
-    # logical,dimension(0:1*bit_length-1)::x_bit_mask,y_bit_mask,z_bit_mask
-
-    # state_diagram = RESHAPE( (/   1, 2, 3, 2, 4, 5, 3, 5,&
-    #    &   0, 1, 3, 2, 7, 6, 4, 5,&
-    #    &   2, 6, 0, 7, 8, 8, 0, 7,&
-    #    &   0, 7, 1, 6, 3, 4, 2, 5,&
-    #    &   0, 9,10, 9, 1, 1,11,11,&
-    #    &   0, 3, 7, 4, 1, 2, 6, 5,&
-    #    &   6, 0, 6,11, 9, 0, 9, 8,&
-    #    &   2, 3, 1, 0, 5, 4, 6, 7,&
-    #    &  11,11, 0, 7, 5, 9, 0, 7,&
-    #    &   4, 3, 5, 2, 7, 0, 6, 1,&
-    #    &   4, 4, 8, 8, 0, 6,10, 6,&
-    #    &   6, 5, 1, 2, 7, 4, 0, 3,&
-    #    &   5, 7, 5, 3, 1, 1,11,11,&
-    #    &   4, 7, 3, 0, 5, 6, 2, 1,&
-    #    &   6, 1, 6,10, 9, 4, 9,10,&
-    #    &   6, 7, 5, 4, 1, 0, 2, 3,&
-    #    &  10, 3, 1, 1,10, 3, 5, 9,&
-    #    &   2, 5, 3, 4, 1, 6, 0, 7,&
-    #    &   4, 4, 8, 8, 2, 7, 2, 3,&
-    #    &   2, 1, 5, 6, 3, 0, 4, 7,&
-    #    &   7, 2,11, 2, 7, 5, 8, 5,&
-    #    &   4, 5, 7, 6, 3, 2, 0, 1,&
-    #    &  10, 3, 2, 6,10, 3, 4, 4,&
-    #    &   6, 1, 7, 0, 5, 2, 4, 3 /), &
-    #    & (/8 ,2, 12 /) )
 
     state_diagram = np.array([
         1, 2, 3, 2, 4, 5, 3, 5, 0, 1, 3, 2, 7, 6, 4, 5, 2, 6, 0, 7, 8, 8, 0, 7, 0, 7, 1,
@@ -90,26 +44,19 @@ def _hilbert3d(x, y, z, bit_length):
         4, 4, 6, 1, 7, 0, 5, 2, 4, 3
     ]).reshape((8, 2, 12), order='F')
 
-    # convert to binary
+    # Convert to binary
     for i in range(bit_length):
         x_bit_mask[i] = _btest(x, i)
         y_bit_mask[i] = _btest(y, i)
         z_bit_mask[i] = _btest(z, i)
 
-    # print(x_bit_mask)
-    # print(y_bit_mask)
-    # print(z_bit_mask)
-
-    # interleave bits
+    # Interleave bits
     for i in range(bit_length):
         i_bit_mask[3 * i + 2] = x_bit_mask[i]
         i_bit_mask[3 * i + 1] = y_bit_mask[i]
         i_bit_mask[3 * i] = z_bit_mask[i]
 
-    # print(i_bit_mask)
-
-    # build Hilbert ordering using state diagram
-    # print('cstate')
+    # Build Hilbert ordering using state diagram
     cstate = 0
     for i in range(bit_length - 1, -1, -1):
         b2 = 0
@@ -128,28 +75,18 @@ def _hilbert3d(x, y, z, bit_length):
         i_bit_mask[3 * i + 1] = _btest(hdigit, 1)
         i_bit_mask[3 * i] = _btest(hdigit, 0)
         cstate = nstate
-    #     print(i)
-    #     print(b2, b1, b0)
-    #     print(sdigit, nstate, hdigit)
-    #     print(i_bit_mask)
-    #     print(cstate)
-    # print('end cstate ---------')
 
-    # save Hilbert key as double precision real ??
     order = 0
     for i in range(3 * bit_length):
         b0 = 0
         if i_bit_mask[i]:
             b0 = 1
         order = order + b0 * (2**i)
-
-    # print(order, type(order))
     return order
 
 
-def hilbert_cpu_list(bounding_box, lmax, levelmax, infofile, ncpu, ndim):
+def _get_cpu_list(bounding_box, lmax, levelmax, infofile, ncpu, ndim):
 
-    # Read bound key
     bound_key = _read_bound_key(infofile=infofile, ncpu=ncpu)
 
     xmin = bounding_box["xmin"]
@@ -158,9 +95,7 @@ def hilbert_cpu_list(bounding_box, lmax, levelmax, infofile, ncpu, ndim):
     ymax = bounding_box["ymax"]
     zmin = bounding_box["zmin"]
     zmax = bounding_box["zmax"]
-
     dmax = max(xmax - xmin, ymax - ymin, zmax - zmin)
-
     for ilevel in range(1, lmax + 1):
         dx = 0.5**ilevel
         if dx < dmax:
@@ -182,16 +117,6 @@ def hilbert_cpu_list(bounding_box, lmax, levelmax, infofile, ncpu, ndim):
         jmax = jmin + 1
         kmin = int(zmin * maxdom)
         kmax = kmin + 1
-    #     imin = int(xmin * dble(maxdom))
-    #     imax = imin + 1
-    #     jmin = int(ymin * dble(maxdom))
-    #     jmax = jmin + 1
-    #     kmin = int(zmin * dble(maxdom))
-    #     kmax = kmin + 1
-    # endif
-
-    # print(dmax, bit_length, maxdom, lmin)
-    # print(imin, imax, jmin, jmax, kmin, kmax)
 
     dkey = (2**(levelmax + 1) // maxdom)**ndim
     ndom = 1
@@ -201,45 +126,17 @@ def hilbert_cpu_list(bounding_box, lmax, levelmax, infofile, ncpu, ndim):
     jdom = [jmin, jmin, jmax, jmax] * 2
     kdom = [kmin] * 4 + [kmax] * 4
 
-    # print(dkey, ndim)
-    # print(idom)
-    # print(jdom)
-    # print(kdom)
-    # idom(1)=imin; idom(2)=imax
-    # idom(3)=imin; idom(4)=imax
-    # idom(5)=imin; idom(6)=imax
-    # idom(7)=imin; idom(8)=imax
-    # jdom(1)=jmin; jdom(2)=jmin
-    # jdom(3)=jmax; jdom(4)=jmax
-    # jdom(5)=jmin; jdom(6)=jmin
-    # jdom(7)=jmax; jdom(8)=jmax
-    # kdom(1)=kmin; kdom(2)=kmin
-    # kdom(3)=kmin; kdom(4)=kmin
-    # kdom(5)=kmax; kdom(6)=kmax
-    # kdom(7)=kmax; kdom(8)=kmax
-
-    # do i=1,ndom
-
     bounding_min = [0, 0, 0, 0, 0, 0, 0, 0]
     bounding_max = [0, 0, 0, 0, 0, 0, 0, 0]
     bounding = None
     for i in range(ndom):
-        # print(i)
         if bit_length > 0:
             bounding = _hilbert3d(idom[i], jdom[i], kdom[i], bit_length)
             order_min = bounding
-            # print('hilbert', order_min)
         else:
             order_min = 0
-            # print('zero', order_min)
-        # print(order_min, bounding)
         bounding_min[i] = order_min * dkey
         bounding_max[i] = (order_min + 1) * dkey
-    # return
-
-    # print(bounding_min)
-    # print(bounding_max)
-    # return
 
     cpu_min = [0, 0, 0, 0, 0, 0, 0, 0]
     cpu_max = [0, 0, 0, 0, 0, 0, 0, 0]
@@ -253,20 +150,48 @@ def hilbert_cpu_list(bounding_box, lmax, levelmax, infofile, ncpu, ndim):
                     and (bound_key[impi + 1] >= bounding_max[i])):
                 cpu_max[i] = impi
 
-    # ncpu_read=0
     cpu_list = []
     for i in range(ndom):
         for j in range(cpu_min[i], cpu_max[i] + 1):
             if j + 1 not in cpu_list:
                 cpu_list.append(j + 1)
 
-    # print(cpu_list)
     return cpu_list
 
 
-# else
-#    ncpu_read=ncpu
-#    do j=1,ncpu
-#       cpu_list(j)=j
-#    end do
-# end  if
+def hilbert_cpu_list(meta, scaling, select, infofile):
+    if meta["ordering type"] == "hilbert":
+        bounding_box = {
+            "xmin": 0,
+            "xmax": 1,
+            "ymin": 0,
+            "ymax": 1,
+            "zmin": 0,
+            "zmax": 1
+        }
+        # Make an array of cell centers according to lmax
+        box_size = (meta["boxlen"] * scaling).magnitude
+        ncells = 2**min(meta["levelmax"], 18)  # limit to 262000 cells
+        half_dxmin = 0.5 * box_size / ncells
+        xyz_centers = Array(values=np.linspace(half_dxmin, box_size - half_dxmin,
+                                               ncells),
+                            unit=1.0 * scaling.units)
+        new_bbox = False
+        for c in "xyz":
+            if c in select:
+                new_bbox = True
+                func_test = select[c](xyz_centers)
+                inds = np.argwhere(func_test).ravel()
+                start = xyz_centers[inds.min()] - (half_dxmin * scaling.units)
+                end = xyz_centers[inds.max()] + (half_dxmin * scaling.units)
+                bounding_box["{}min".format(c)] = start._array / box_size
+                bounding_box["{}max".format(c)] = end._array / box_size
+                select["xyz_{}".format(c)] = select.pop(c)
+
+        if new_bbox:
+            return _get_cpu_list(bounding_box=bounding_box,
+                                 lmax=meta["lmax"],
+                                 levelmax=meta["levelmax"],
+                                 infofile=infofile,
+                                 ncpu=meta["ncpu"],
+                                 ndim=meta["ndim"])

--- a/src/osyris/io/hilbert.py
+++ b/src/osyris/io/hilbert.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Osyris contributors (https://github.com/nvaytet/osyris)
+
+import numpy as np
+
+
+def hilbert_cpu_list(bounding_box, lmax, levelmax, infofile, ncpu):
+
+    # Read bound key
+    bound_key = read_bound_key(infofile=infofile, ncpu=ncpu)
+
+    xmin = bounding_box["xmin"]
+    xmax = bounding_box["xmax"]
+    ymin = bounding_box["ymin"]
+    ymax = bounding_box["ymax"]
+    zmin = bounding_box["zmin"]
+    zmax = bounding_box["zmax"]
+
+    dmax = max(xmax - xmin, ymax - ymin, zmax - zmin)
+
+    for ilevel in range(1, lmax + 1):
+        dx = 0.5**ilevel
+        if dx < dmax:
+            break
+
+    lmin = ilevel
+    bit_length = lmin - 1
+    maxdom = 2**bit_length
+    imin = 0
+    imax = 0
+    jmin = 0
+    jmax = 0
+    kmin = 0
+    kmax = 0
+    if bit_length > 0:
+        imin = int(xmin * maxdom)
+        imax = imin + 1
+        jmin = int(ymin * maxdom)
+        jmax = jmin + 1
+        kmin = int(zmin * maxdom)
+        kmax = kmin + 1
+    #     imin = int(xmin * dble(maxdom))
+    #     imax = imin + 1
+    #     jmin = int(ymin * dble(maxdom))
+    #     jmax = jmin + 1
+    #     kmin = int(zmin * dble(maxdom))
+    #     kmax = kmin + 1
+    # endif
+
+    dkey = (2**(levelmax + 1) / maxdom)**ndim
+    ndom = 1
+    if bit_length > 0:
+        ndom = 8
+    idom = [[imin, imax]] * 4
+    jdom = [[jmin, jmax]] * 4
+    kdom = [[kmin, kmax]] * 4
+
+# idom(1)=imin; idom(2)=imax
+# idom(3)=imin; idom(4)=imax
+# idom(5)=imin; idom(6)=imax
+# idom(7)=imin; idom(8)=imax
+# jdom(1)=jmin; jdom(2)=jmin
+# jdom(3)=jmax; jdom(4)=jmax
+# jdom(5)=jmin; jdom(6)=jmin
+# jdom(7)=jmax; jdom(8)=jmax
+# kdom(1)=kmin; kdom(2)=kmin
+# kdom(3)=kmin; kdom(4)=kmin
+# kdom(5)=kmax; kdom(6)=kmax
+# kdom(7)=kmax; kdom(8)=kmax
+
+
+#    do i=1,ndom
+#       if(bit_length>0)then
+#          call hilbert3d(idom(i),jdom(i),kdom(i),bounding(1),bit_length,1)
+#          order_min=bounding(1)
+#       else
+#          order_min=0.0d0
+#       endif
+#       bounding_min(i)=(order_min)*dkey
+#       bounding_max(i)=(order_min+1.0D0)*dkey
+#    end do
+
+#    cpu_min=0; cpu_max=0
+#    do impi=1,ncpu
+#       do i=1,ndom
+#          if (   bound_key(impi-1).le.bounding_min(i).and.&
+#               & bound_key(impi  ).gt.bounding_min(i))then
+#             cpu_min(i)=impi
+#          endif
+#          if (   bound_key(impi-1).lt.bounding_max(i).and.&
+#               & bound_key(impi  ).ge.bounding_max(i))then
+#             cpu_max(i)=impi
+#          endif
+#       end do
+#    end do
+
+#    ncpu_read=0
+#    do i=1,ndom
+#       do j=cpu_min(i),cpu_max(i)
+#          if(.not. cpu_read(j))then
+#             ncpu_read=ncpu_read+1
+#             cpu_list(ncpu_read)=j
+#             cpu_read(j)=.true.
+#          endif
+#       enddo
+#    enddo
+# else
+#    ncpu_read=ncpu
+#    do j=1,ncpu
+#       cpu_list(j)=j
+#    end do
+# end  if
+
+
+def read_bound_key(infofile, ncpu):
+    """
+    Read hilbert bound key.
+    """
+    with open(infofile) as f:
+        content = f.readlines()
+    starting_line = None
+    for num, line in enumerate(content):
+        if len(set(["DOMAIN", "ind_min", "ind_max"]) - set(line.split())) == 0:
+            starting_line = num + 1
+            break
+    bound_key = []
+    if starting_line is not None:
+        for n in range(ncpu):
+            line = content[starting_line + n].split()
+            bound_key.append(line[1])
+        bound_key.append(content[starting_line + ncpu - 1].split()[2])
+
+    return np.array(bound_key, dtype=float)

--- a/src/osyris/io/load.py
+++ b/src/osyris/io/load.py
@@ -44,7 +44,7 @@ def load(nout=1,
 
     # Take into account user specified lmax
     if lmax is not None:
-        data.meta["lmax"] = lmax
+        data.meta["lmax"] = min(lmax, data.meta["levelmax"])
     else:
         data.meta["lmax"] = data.meta["levelmax"]
 
@@ -186,8 +186,9 @@ def load(nout=1,
     # Merge all the data pieces into the Arrays
     for group in loaders.values():
         for key, item in group.variables.items():
-            data[key] = Array(values=np.concatenate(list(item["pieces"].values())),
-                              unit=1.0 * item["unit"].units)
+            # data[key] = Array(values=np.concatenate(list(item["pieces"].values())),
+            #                   unit=1.0 * item["unit"].units)
+            data[key] = np.concatenate(list(item["pieces"].values()))
 
     # If vector quantities are found, make them into vector Arrays
     make_vector_arrays(data)

--- a/src/osyris/io/load.py
+++ b/src/osyris/io/load.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 from ..config import parameters, additional_variables
+from .hilbert import hilbert_cpu_list
 from . import utils
 from ..core import Dataset, Array
 from .amr import AmrLoader
@@ -11,7 +12,13 @@ from .hydro import HydroLoader
 from .rt import RtLoader
 
 
-def load(nout=1, scale=None, path="", select=None, lmax=None, cpu_list=None):
+def load(nout=1,
+         scale=None,
+         path="",
+         select=None,
+         lmax=None,
+         cpu_list=None,
+         bounding_box=None):
 
     data = Dataset()
 
@@ -43,7 +50,15 @@ def load(nout=1, scale=None, path="", select=None, lmax=None, cpu_list=None):
 
     # Take into account user specified cpu list
     if cpu_list is None:
-        cpu_list = range(1, data.meta["ncpu"] + 1)
+        if bounding_box is not None and data.meta["ordering type"] == "hilbert":
+            cpu_list = hilbert_cpu_list(bounding_box=bounding_box,
+                                        lmax=data.meta["lmax"],
+                                        levelmax=data.meta["levelmax"],
+                                        infofile=infofile,
+                                        ncpu=data.meta["ncpu"])
+            print(cpu_list)
+        else:
+            cpu_list = range(1, data.meta["ncpu"] + 1)
 
     code_units = {
         "ud": data.meta["unit_d"],

--- a/src/osyris/io/load.py
+++ b/src/osyris/io/load.py
@@ -3,9 +3,8 @@
 
 import numpy as np
 from ..config import parameters, additional_variables
-# from .hilbert import hilbert_cpu_list
 from . import utils
-from ..core import Dataset, Array
+from ..core import Dataset
 from .amr import AmrLoader
 from .grav import GravLoader
 from .hydro import HydroLoader
@@ -13,14 +12,7 @@ from .rt import RtLoader
 from .units import get_unit
 
 
-def load(
-        nout=1,
-        scale=None,
-        path="",
-        select=None,
-        # lmax=None,
-        cpu_list=None,
-        bounding_box=None):
+def load(nout=1, scale=None, path="", select=None, cpu_list=None, bounding_box=None):
 
     data = Dataset()
 
@@ -41,32 +33,15 @@ def load(
     data.meta["scale"] = scale
     data.meta["infile"] = infile
     data.meta["path"] = path
-    # data.meta["boxsize"] = data.meta["boxlen"] * data.meta["unit_l"]
     data.meta["time"] = data.meta["time"] * get_unit(
         "time", data.meta["unit_d"], data.meta["unit_l"], data.meta["unit_t"])
 
     # Take into account user specified lmax
-    # if lmax is not None:
     if "level" in select:
         data.meta["lmax"] = utils.find_max_amr_level(levelmax=data.meta["levelmax"],
                                                      select=select)
-        # data.meta["lmax"] = min(lmax, data.meta["levelmax"])
-        print(data.meta["lmax"])
     else:
         data.meta["lmax"] = data.meta["levelmax"]
-
-    # # Take into account user specified cpu list
-    # if cpu_list is None:
-    #     if bounding_box is not None and data.meta["ordering type"] == "hilbert":
-    #         cpu_list = hilbert_cpu_list(bounding_box=bounding_box,
-    #                                     lmax=data.meta["lmax"],
-    #                                     levelmax=data.meta["levelmax"],
-    #                                     infofile=infofile,
-    #                                     ncpu=data.meta["ncpu"],
-    #                                     ndim=data.meta["ndim"])
-    #         print(cpu_list)
-    #     else:
-    #         cpu_list = range(1, data.meta["ncpu"] + 1)
 
     code_units = {
         "ud": data.meta["unit_d"],
@@ -81,10 +56,6 @@ def load(
                   code_units=code_units,
                   meta=data.meta,
                   infofile=infofile),
-        # ndim=data.meta["ndim"],
-        # ordering=data.meta["ordering type"],
-        # boxlen=data.meta["boxlen"],
-        # levelmax=data.meta["levelmax"]),
         "hydro":
         HydroLoader(infile=infile, select=select, code_units=code_units),
         "grav":
@@ -103,28 +74,10 @@ def load(
         if loader.initialized:
             loaders[group] = loader
 
-    # # Take into account user specified lmax
-    # if lmax is not None:
-    #     data.meta["lmax"] = min(lmax, data.meta["levelmax"])
-    # else:
-    #     data.meta["lmax"] = data.meta["levelmax"]
-
     # Take into account user specified cpu list
     if cpu_list is None:
         cpu_list = loader_list["amr"].cpu_list if loader_list[
             "amr"].cpu_list is not None else range(1, data.meta["ncpu"] + 1)
-    print(cpu_list)
-
-    # if bounding_box is not None and data.meta["ordering type"] == "hilbert":
-    #     cpu_list = hilbert_cpu_list(bounding_box=bounding_box,
-    #                                 lmax=data.meta["lmax"],
-    #                                 levelmax=data.meta["levelmax"],
-    #                                 infofile=infofile,
-    #                                 ncpu=data.meta["ncpu"],
-    #                                 ndim=data.meta["ndim"])
-    #     print(cpu_list)
-    # else:
-    #     cpu_list = range(1, data.meta["ncpu"] + 1)
 
     print("Processing {} files in {}".format(len(cpu_list), infile))
 

--- a/src/osyris/io/load.py
+++ b/src/osyris/io/load.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 from ..config import parameters, additional_variables
-from .hilbert import hilbert_cpu_list
+# from .hilbert import hilbert_cpu_list
 from . import utils
 from ..core import Dataset, Array
 from .amr import AmrLoader
 from .grav import GravLoader
 from .hydro import HydroLoader
 from .rt import RtLoader
+from .units import get_unit
 
 
 def load(nout=1,
@@ -39,8 +40,9 @@ def load(nout=1,
     data.meta["scale"] = scale
     data.meta["infile"] = infile
     data.meta["path"] = path
-    data.meta["boxsize"] = data.meta["boxlen"] * data.meta["unit_l"]
-    data.meta["time"] = data.meta["time"] * data.meta["unit_t"]
+    # data.meta["boxsize"] = data.meta["boxlen"] * data.meta["unit_l"]
+    data.meta["time"] = data.meta["time"] * get_unit(
+        "time", data.meta["unit_d"], data.meta["unit_l"], data.meta["unit_t"])
 
     # Take into account user specified lmax
     if lmax is not None:
@@ -48,18 +50,18 @@ def load(nout=1,
     else:
         data.meta["lmax"] = data.meta["levelmax"]
 
-    # Take into account user specified cpu list
-    if cpu_list is None:
-        if bounding_box is not None and data.meta["ordering type"] == "hilbert":
-            cpu_list = hilbert_cpu_list(bounding_box=bounding_box,
-                                        lmax=data.meta["lmax"],
-                                        levelmax=data.meta["levelmax"],
-                                        infofile=infofile,
-                                        ncpu=data.meta["ncpu"],
-                                        ndim=data.meta["ndim"])
-            print(cpu_list)
-        else:
-            cpu_list = range(1, data.meta["ncpu"] + 1)
+    # # Take into account user specified cpu list
+    # if cpu_list is None:
+    #     if bounding_box is not None and data.meta["ordering type"] == "hilbert":
+    #         cpu_list = hilbert_cpu_list(bounding_box=bounding_box,
+    #                                     lmax=data.meta["lmax"],
+    #                                     levelmax=data.meta["levelmax"],
+    #                                     infofile=infofile,
+    #                                     ncpu=data.meta["ncpu"],
+    #                                     ndim=data.meta["ndim"])
+    #         print(cpu_list)
+    #     else:
+    #         cpu_list = range(1, data.meta["ncpu"] + 1)
 
     code_units = {
         "ud": data.meta["unit_d"],
@@ -69,7 +71,15 @@ def load(nout=1,
 
     loader_list = {
         "amr":
-        AmrLoader(scale=scale, code_units=code_units, ndim=data.meta["ndim"]),
+        AmrLoader(scale=scale,
+                  select=select,
+                  code_units=code_units,
+                  meta=data.meta,
+                  infofile=infofile),
+        # ndim=data.meta["ndim"],
+        # ordering=data.meta["ordering type"],
+        # boxlen=data.meta["boxlen"],
+        # levelmax=data.meta["levelmax"]),
         "hydro":
         HydroLoader(infile=infile, select=select, code_units=code_units),
         "grav":
@@ -88,7 +98,30 @@ def load(nout=1,
         if loader.initialized:
             loaders[group] = loader
 
-    print("Processing {} files in {}".format(data.meta["ncpu"], infile))
+    # # Take into account user specified lmax
+    # if lmax is not None:
+    #     data.meta["lmax"] = min(lmax, data.meta["levelmax"])
+    # else:
+    #     data.meta["lmax"] = data.meta["levelmax"]
+
+    # Take into account user specified cpu list
+    if cpu_list is None:
+        cpu_list = loader_list["amr"].cpu_list if loader_list[
+            "amr"].cpu_list is not None else range(1, data.meta["ncpu"] + 1)
+    print(cpu_list)
+
+    # if bounding_box is not None and data.meta["ordering type"] == "hilbert":
+    #     cpu_list = hilbert_cpu_list(bounding_box=bounding_box,
+    #                                 lmax=data.meta["lmax"],
+    #                                 levelmax=data.meta["levelmax"],
+    #                                 infofile=infofile,
+    #                                 ncpu=data.meta["ncpu"],
+    #                                 ndim=data.meta["ndim"])
+    #     print(cpu_list)
+    # else:
+    #     cpu_list = range(1, data.meta["ncpu"] + 1)
+
+    print("Processing {} files in {}".format(len(cpu_list), infile))
 
     # Allocate work arrays
     twotondim = 2**data.meta["ndim"]

--- a/src/osyris/io/load.py
+++ b/src/osyris/io/load.py
@@ -55,7 +55,8 @@ def load(nout=1,
                                         lmax=data.meta["lmax"],
                                         levelmax=data.meta["levelmax"],
                                         infofile=infofile,
-                                        ncpu=data.meta["ncpu"])
+                                        ncpu=data.meta["ncpu"],
+                                        ndim=data.meta["ndim"])
             print(cpu_list)
         else:
             cpu_list = range(1, data.meta["ncpu"] + 1)

--- a/src/osyris/io/load.py
+++ b/src/osyris/io/load.py
@@ -177,8 +177,6 @@ def load(nout=1, scale=None, path="", select=None, cpu_list=None, bounding_box=N
     # Merge all the data pieces into the Arrays
     for group in loaders.values():
         for key, item in group.variables.items():
-            # data[key] = Array(values=np.concatenate(list(item["pieces"].values())),
-            #                   unit=1.0 * item["unit"].units)
             data[key] = np.concatenate(list(item["pieces"].values()))
 
     # If vector quantities are found, make them into vector Arrays

--- a/src/osyris/io/loader.py
+++ b/src/osyris/io/loader.py
@@ -46,7 +46,6 @@ class Loader():
         for key, func in select.items():
             if not isinstance(func, bool):
                 if key in self.variables:
-                    #print(self.variables[key]["buffer"][:ncache, :])
                     conditions[key] = func(self.variables[key]["buffer"][:ncache, :])
         return conditions
 

--- a/src/osyris/io/loader.py
+++ b/src/osyris/io/loader.py
@@ -44,6 +44,7 @@ class Loader():
         for key, func in select.items():
             if not isinstance(func, bool):
                 if key in self.variables:
+                    print(self.variables[key]["buffer"][:ncache, :])
                     conditions[key] = func(self.variables[key]["buffer"][:ncache, :])
         return conditions
 

--- a/src/osyris/io/loader.py
+++ b/src/osyris/io/loader.py
@@ -1,5 +1,6 @@
 import numpy as np
 from . import utils
+from ..core import Array
 
 
 class Loader():
@@ -12,8 +13,9 @@ class Loader():
 
     def allocate_buffers(self, ngridmax, twotondim):
         for item in self.variables.values():
-            item["buffer"] = np.zeros([ngridmax, twotondim],
-                                      dtype=np.dtype(item["type"]))
+            item["buffer"] = Array(values=np.zeros([ngridmax, twotondim],
+                                                   dtype=np.dtype(item["type"])),
+                                   unit=1.0 * item["unit"].units)
 
     def read_header(self, *args, **kwargs):
         return
@@ -30,7 +32,7 @@ class Loader():
     def read_variables(self, ncache, ind, ilevel, cpuid, info):
         for item in self.variables.values():
             if item["read"]:
-                item["buffer"][:ncache, ind] = np.array(
+                item["buffer"]._array[:ncache, ind] = np.array(
                     utils.read_binary_data(
                         fmt="{}{}".format(ncache, item["type"]),
                         content=self.bytes,
@@ -44,7 +46,7 @@ class Loader():
         for key, func in select.items():
             if not isinstance(func, bool):
                 if key in self.variables:
-                    print(self.variables[key]["buffer"][:ncache, :])
+                    #print(self.variables[key]["buffer"][:ncache, :])
                     conditions[key] = func(self.variables[key]["buffer"][:ncache, :])
         return conditions
 

--- a/src/osyris/io/units.py
+++ b/src/osyris/io/units.py
@@ -13,7 +13,8 @@ def get_unit(string, ud, ul, ut):
         "acceleration": (ul / ut**2) * (units.cm / (units.s**2)),
         "thermal_pressure": ud * ((ul / ut)**2) * (units.erg / (units.cm**3)),
         "energy": ud * ((ul / ut)**2) * (units.erg / (units.cm**3)),
-        "temperature": 1.0 * units.K
+        "temperature": 1.0 * units.K,
+        "time": ut * units.s
     }
     ramses_units.update(dict.fromkeys(['x', 'y', 'z', 'dx'], (ul * units.cm)))
 

--- a/src/osyris/io/utils.py
+++ b/src/osyris/io/utils.py
@@ -114,17 +114,12 @@ def make_vector_arrays(data):
                 rawkey = key.replace("_x", "")
                 comp_list = [key.replace("_x_", "_{}_".format(c)) for c in components]
 
-            # comps_found = [rawkey + "_" + c in data for c in components]
-
             if comp_list is not None:
                 if all([item in data for item in comp_list]):
-                    # for c in components:
-                    #     print(rawkey + "_" + c, data[rawkey + "_" + c].values.shape)
                     data[rawkey] = Array(values=np.array(
                         [data[c].values for c in comp_list]).T,
                                          unit=data[key].unit)
                     for c in comp_list:
-                        # comp = rawkey + "_" + c
                         del data[c]
                         skip.append(c)
 

--- a/src/osyris/io/utils.py
+++ b/src/osyris/io/utils.py
@@ -104,19 +104,29 @@ def make_vector_arrays(data):
     if len(components) > 1:
         skip = []
         for key in list(data.keys()):
+            # Make list of 3 components
+            comp_list = None
+            rawkey = None
             if key.endswith("_x") and key not in skip:
                 rawkey = key[:-2]
-                comps_found = [rawkey + "_" + c in data for c in components]
-                if all(comps_found):
-                    for c in components:
-                        print(rawkey + "_" + c, data[rawkey + "_" + c].values.shape)
+                comp_list = [rawkey + "_" + c for c in components]
+            if "_x_" in key and key not in skip:
+                rawkey = key.replace("_x", "")
+                comp_list = [key.replace("_x_", "_{}_".format(c)) for c in components]
+
+            # comps_found = [rawkey + "_" + c in data for c in components]
+
+            if comp_list is not None:
+                if all([item in data for item in comp_list]):
+                    # for c in components:
+                    #     print(rawkey + "_" + c, data[rawkey + "_" + c].values.shape)
                     data[rawkey] = Array(values=np.array(
-                        [data[rawkey + "_" + c].values for c in components]).T,
+                        [data[c].values for c in comp_list]).T,
                                          unit=data[key].unit)
-                    for c in components:
-                        comp = rawkey + "_" + c
-                        del data[comp]
-                        skip.append(comp)
+                    for c in comp_list:
+                        # comp = rawkey + "_" + c
+                        del data[c]
+                        skip.append(c)
 
 
 def find_max_amr_level(levelmax, select):

--- a/src/osyris/plot/plane.py
+++ b/src/osyris/plot/plane.py
@@ -10,7 +10,6 @@ from .parser import parse_layer
 from ..core import Plot, Array
 from ..core.tools import to_bin_centers, apply_mask
 from scipy.stats import binned_statistic_2d
-from scipy.ndimage import distance_transform_edt
 
 
 def plane(*layers,
@@ -191,8 +190,8 @@ def plane(*layers,
 
     # To keep memory usage down to a minimum, we process the image one column at a time
     for i in range(indices.shape[-1]):
-        # We know we are looking only at a column of cells, so we make a line from the two
-        # end points, compute distance to the line to filter out the cells
+        # We know we are looking only at a column of cells, so we make a line from the
+        # two end points, compute distance to the line to filter out the cells
         x1 = pixel_positions[0, i, :]
         x2 = pixel_positions[-1, i, :]
         x0_minus_x1 = coords.array - x1

--- a/src/osyris/plot/plane.py
+++ b/src/osyris/plot/plane.py
@@ -77,14 +77,17 @@ def plane(*layers,
     # Distance to the plane
     xyz = dataset["xyz"] - origin
     diagonal = dataset["dx"] * np.sqrt(dataset.meta["ndim"]) * 0.5
-    dist1 = np.sum(xyz * dir_vecs[0],
-                   axis=1)  # / np.linalg.norm(dir_vecs[0][1])
+    dist1 = np.sum(xyz * dir_vecs[0], axis=1)
 
     # Select cells in contact with plane
     cells_in_plane = np.abs(dist1) <= diagonal
     # Project coordinates onto the plane by taking dot product with axes
     # vectors
     select = np.ravel(np.where(cells_in_plane))
+
+    if len(select) == 0:
+        raise RuntimeError("No cells were selected to construct the plane. "
+                           "The resulting figure would be empty.")
     coords = xyz[select]
     datax = np.inner(coords, dir_vecs[1])
     datay = np.inner(coords, dir_vecs[2])

--- a/src/osyris/plot/plane.py
+++ b/src/osyris/plot/plane.py
@@ -192,7 +192,7 @@ def plane(*layers,
     # To keep memory usage down to a minimum, we process the image one column at a time
     for i in range(indices.shape[-1]):
         # We know we are looking only at a column of cells, so we make a line from the
-        # two end points, compute distance to the line to filter out the cells
+        # two end points (x1, x2), compute distance to the line to filter out the cells
         x1 = pixel_positions[0, i, :]
         x2 = pixel_positions[-1, i, :]
         x0_minus_x1 = coords.array - x1

--- a/src/osyris/plot/plane.py
+++ b/src/osyris/plot/plane.py
@@ -170,15 +170,26 @@ def plane(*layers,
 
     # Use Scipy's distance transform to fill blanks with nearest neighbours
     condition = np.isnan(binned[-1])
-    transform = tuple(
-        distance_transform_edt(condition, return_distances=False, return_indices=True))
+    distances, transform = distance_transform_edt(condition,
+                                                  return_distances=True,
+                                                  return_indices=True)
+    print(distances)
+    print(distances.shape)
+
+    im_dx = xedges[1] - xedges[0]
+    dx_max = 2.0 * np.amax(datadx.array / im_dx)
+
+    transform = tuple(transform)
+    # transform = [...]
 
     # Define a mask to mask aread outside of the domain range, which have
     # been filled by the previous transform step
-    xx = np.broadcast_to(xcenters, [resolution, resolution])
-    yy = np.broadcast_to(ycenters, [resolution, resolution]).T
-    mask = np.logical_or.reduce((xx < limits['xmin'], xx > limits['xmax'],
-                                 yy < limits['ymin'], yy > limits['ymax']))
+    # xx = np.broadcast_to(xcenters, [resolution, resolution])
+    # yy = np.broadcast_to(ycenters, [resolution, resolution]).T
+    # mask = np.logical_or.reduce(
+    #     (xx < limits['xmin'], xx > limits['xmax'], yy < limits['ymin'],
+    #      yy > limits['ymax'], distances > dx_max))
+    mask = distances > dx_max
     mask_vec = np.broadcast_to(mask.reshape(*mask.shape, 1), mask.shape + (3, ))
 
     counter = 0
@@ -208,4 +219,4 @@ def plane(*layers,
             figure["ax"].set_aspect("equal")
         to_return.update({"fig": figure["fig"], "ax": figure["ax"]})
 
-    return Plot(**to_return)
+    return Plot(**to_return), distances

--- a/src/osyris/plot/plane.py
+++ b/src/osyris/plot/plane.py
@@ -172,14 +172,6 @@ def plane(*layers,
     condition = np.isnan(binned[-1])
     transform = tuple(
         distance_transform_edt(condition, return_distances=False, return_indices=True))
-    # print(distances)
-    # print(distances.shape)
-
-    # im_dx = xedges[1] - xedges[0]
-    # dx_max = 2.0 * np.amax(datadx.array / im_dx)
-
-    # transform = tuple(transform)
-    # transform = [...]
 
     # Define a mask to mask aread outside of the domain range, which have
     # been filled by the previous transform step
@@ -187,10 +179,6 @@ def plane(*layers,
     yy = np.broadcast_to(ycenters, [resolution, resolution]).T
     mask = np.logical_or.reduce((xx < limits['xmin'], xx > limits['xmax'],
                                  yy < limits['ymin'], yy > limits['ymax']))
-    # mask = np.logical_or.reduce(
-    #     (xx < limits['xmin'], xx > limits['xmax'], yy < limits['ymin'],
-    #      yy > limits['ymax'], distances > dx_max))
-    # mask = distances > dx_max
     mask_vec = np.broadcast_to(mask.reshape(*mask.shape, 1), mask.shape + (3, ))
 
     counter = 0

--- a/src/osyris/plot/plane.py
+++ b/src/osyris/plot/plane.py
@@ -216,8 +216,8 @@ def plane(*layers,
         figure = render(x=xcenters, y=ycenters, data=to_render, ax=ax)
         figure["ax"].set_xlabel(dataset["xyz"].x.label)
         figure["ax"].set_ylabel(dataset["xyz"].y.label)
-        if ax is None:
-            figure["ax"].set_aspect("equal")
+        # if ax is None:
+        #     figure["ax"].set_aspect("equal")
         to_return.update({"fig": figure["fig"], "ax": figure["ax"]})
 
     return Plot(**to_return)

--- a/src/osyris/plot/plane.py
+++ b/src/osyris/plot/plane.py
@@ -180,26 +180,30 @@ def plane(*layers,
     # ygrid, xgrid = np.meshgrid(ycenters, xcenters, indexing='xy')
     # xgrid = Array(values=xgrid, unit=xyz.unit)
     # ygrid = Array(values=ygrid, unit=xyz.unit)
+    print('xgrid.shape', xgrid.shape)
 
     indices = np.zeros_like(binned[-1], dtype=int)
     mask = np.zeros_like(binned[-1], dtype=bool)
 
     pos = (xgrid.reshape(xgrid.shape + (1, )) * dir_vecs[1] +
            ygrid.reshape(ygrid.shape + (1, )) * dir_vecs[2]) + origin.array
+    print('dir_vecs', dir_vecs[1], dir_vecs[2])
     print('pos', pos.shape)
+    print(pos)
     print('binned', binned[-1].shape)
-    fil = np.ravel(np.where(datadx >= xedges[1] - xedges[0]))
+    fil = np.ravel(np.where(datadx >= 0.5 * (xedges[1] - xedges[0])))
     print(len(fil))
 
     xcoords = coords.x.array[fil]
     ycoords = coords.y.array[fil]
     filtered_dx = datadx.array[fil]
+    global_indices = np.arange(len(datadx))[fil]
 
     times = [0, 0, 0, 0]
     import time
     print('indices.shape', indices.shape)
 
-    for i in range(indices.shape[0]):
+    for i in range(indices.shape[-1]):
         # Make a line from the two end points and compute distance to the line to filter out all points
         # first and last points in row
         x1 = pos[0, i, :]
@@ -207,24 +211,24 @@ def plane(*layers,
         x0_minus_x1 = coords.array[fil] - x1
         x0_minus_x2 = coords.array[fil] - x2
         x2_minus_x1 = x2 - x1
-        print('x1', x1, x1.shape, 'x2', x2, x2.shape)
-        print(coords.array[fil].shape)
-        print('x0_minus_x1.shape', x0_minus_x1.shape)
-        print('x0_minus_x2.shape', x0_minus_x2.shape)
+        # print('x1', x1, x1.shape, 'x2', x2, x2.shape)
+        # print(coords.array[fil].shape)
+        # print('x0_minus_x1.shape', x0_minus_x1.shape)
+        # print('x0_minus_x2.shape', x0_minus_x2.shape)
         distance_to_line = np.cross(x0_minus_x1, x0_minus_x2)
         if distance_to_line.ndim > 1:
             distance_to_line = np.linalg.norm(distance_to_line, axis=-1)
         else:
             distance_to_line = np.abs(distance_to_line)
         distance_to_line /= np.linalg.norm(x2_minus_x1)
-        print('cross', np.cross(x0_minus_x1, x0_minus_x2).shape)
+        # print('cross', np.cross(x0_minus_x1, x0_minus_x2).shape)
         # print('outer', np.outer(x0_minus_x1, x0_minus_x2).shape)
-        print(distance_to_line.shape)
-        print('min/max', distance_to_line.min(), distance_to_line.max())
+        # print(distance_to_line.shape)
+        # print('min/max', distance_to_line.min(), distance_to_line.max())
         row = np.ravel(np.where(distance_to_line < np.sqrt(3.0) * filtered_dx))
         # row = np.ravel(np.where(np.abs(ycoords - ycenters[i]) < filtered_dx))
-        print(i, len(row))
-        print(xcoords[row].min(), xcoords[row].max())
+        # print(i, len(row))
+        # print(xcoords[row].min(), xcoords[row].max())
         start = time.time()
         distx = pos[..., i, 0:1] - xcoords[row]  #.reshape((len(coords.x.array), 1))
         disty = pos[..., i, 1:2] - ycoords[row]  #.reshape((len(coords.y.array), 1))
@@ -241,25 +245,28 @@ def plane(*layers,
         ind = np.logical_and(
             np.abs(distx) <= filtered_dx[row],
             np.abs(disty) <= filtered_dx[row])
-        print('ind.shape', ind.shape)
+        # print('ind.shape', ind.shape)
         end = time.time()
         times[1] += end - start
         start = end
         # print(ind.shape)
         # print(ind.max(axis=-1))
         index_found = ind.max(axis=-1)
-        index_value = ind.argmax(axis=-1)
+        index_value = global_indices[row][ind.argmax(axis=-1)]
         end = time.time()
         times[2] += end - start
         start = end
 
         cond = index_found == True
+        # print('cond', cond)
+        # print('index_found', index_found)
+        # print('index_value', index_value)
         indices[:, i][cond] = index_value[cond]
-        mask[:, i][np.logical_and(~cond, condition[:, i])] = True
+        # mask[:, i][np.logical_and(~cond, condition[:, i])] = True
         end = time.time()
         times[3] += end - start
         start = end
-        break
+        # break
 
     print('times', times)
     # print(indices.shape)

--- a/src/osyris/plot/plane.py
+++ b/src/osyris/plot/plane.py
@@ -247,8 +247,8 @@ def plane(*layers,
         figure = render(x=xcenters, y=ycenters, data=to_render, ax=ax)
         figure["ax"].set_xlabel(dataset["xyz"].x.label)
         figure["ax"].set_ylabel(dataset["xyz"].y.label)
-        # if ax is None:
-        #     figure["ax"].set_aspect("equal")
+        if ax is None:
+            figure["ax"].set_aspect("equal")
         to_return.update({"fig": figure["fig"], "ax": figure["ax"]})
 
     return Plot(**to_return)

--- a/src/osyris/plot/plane.py
+++ b/src/osyris/plot/plane.py
@@ -183,7 +183,8 @@ def plane(*layers,
     pixel_positions = xgrid.reshape(xgrid.shape + (1, )) * dir_vecs[1] + ygrid.reshape(
         ygrid.shape + (1, )) * dir_vecs[2]
     # We only need to search in the cells above a certain size
-    large_cells = np.ravel(np.where(datadx >= 0.5 * (xedges[1] - xedges[0])))
+    large_cells = np.ravel(
+        np.where(datadx >= 0.25 * (min(xedges[1] - xedges[0], yedges[1] - yedges[0]))))
     coords = coords[large_cells]
     large_cells_dx = datadx.array[large_cells]
     global_indices = np.arange(len(datadx))[large_cells]

--- a/src/osyris/plot/plane.py
+++ b/src/osyris/plot/plane.py
@@ -170,26 +170,27 @@ def plane(*layers,
 
     # Use Scipy's distance transform to fill blanks with nearest neighbours
     condition = np.isnan(binned[-1])
-    distances, transform = distance_transform_edt(condition,
-                                                  return_distances=True,
-                                                  return_indices=True)
-    print(distances)
-    print(distances.shape)
+    transform = tuple(
+        distance_transform_edt(condition, return_distances=False, return_indices=True))
+    # print(distances)
+    # print(distances.shape)
 
-    im_dx = xedges[1] - xedges[0]
-    dx_max = 2.0 * np.amax(datadx.array / im_dx)
+    # im_dx = xedges[1] - xedges[0]
+    # dx_max = 2.0 * np.amax(datadx.array / im_dx)
 
-    transform = tuple(transform)
+    # transform = tuple(transform)
     # transform = [...]
 
     # Define a mask to mask aread outside of the domain range, which have
     # been filled by the previous transform step
-    # xx = np.broadcast_to(xcenters, [resolution, resolution])
-    # yy = np.broadcast_to(ycenters, [resolution, resolution]).T
+    xx = np.broadcast_to(xcenters, [resolution, resolution])
+    yy = np.broadcast_to(ycenters, [resolution, resolution]).T
+    mask = np.logical_or.reduce((xx < limits['xmin'], xx > limits['xmax'],
+                                 yy < limits['ymin'], yy > limits['ymax']))
     # mask = np.logical_or.reduce(
     #     (xx < limits['xmin'], xx > limits['xmax'], yy < limits['ymin'],
     #      yy > limits['ymax'], distances > dx_max))
-    mask = distances > dx_max
+    # mask = distances > dx_max
     mask_vec = np.broadcast_to(mask.reshape(*mask.shape, 1), mask.shape + (3, ))
 
     counter = 0
@@ -219,4 +220,4 @@ def plane(*layers,
             figure["ax"].set_aspect("equal")
         to_return.update({"fig": figure["fig"], "ax": figure["ax"]})
 
-    return Plot(**to_return), distances
+    return Plot(**to_return)


### PR DESCRIPTION
- Add `cpu_list` argument to load function to enable selective loading of cpu files:
```Py
data = osyris.load(71, scale="au", path="data", cpu_list=[5, 9, 20, 30, 60])
```

- Add hilbert based loader, when selective loading is carried out on the x,y,z coordinates:
```Py
data = osyris.load(71, scale="au",
    select={"x": lambda x : x > 5500. * osyris.units('au')})
```
It uses the hilbert key to construct a list of cpus to read and then feeds that list to the loader in the same way as shown above. It is basically a translation of the code in [`amr2map`](https://bitbucket.org/rteyssie/ramses/src/a5f684caf9eb51755c56a28f7c32b3ba10cfce22/utils/f90/amr2map.f90#lines-192) from fortran to python.

- `lmax` has been removed in arguments of `load`, instead use `data = osyris.load(71, scale="au", select={"level": lambda l : l < 12})`

- New algorithm for plane plots: hybrid method with first histogramming and then filling the blanks by finding the actual cell in the 3d domain that contains the blank image pixel.
Before:
![Screenshot at 2021-09-06 01-06-43](https://user-images.githubusercontent.com/39047984/132143797-7f0cc90f-6765-4860-bf9b-d5c99d0418c5.png)

After:
![Screenshot at 2021-09-05 23-39-48](https://user-images.githubusercontent.com/39047984/132143763-a0cce355-51ab-4311-a033-cd5e1b10ae42.png)

Also:
Fixes #16 